### PR TITLE
Fix HTTPS

### DIFF
--- a/ingress.yaml
+++ b/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   tls:
     - hosts:
-        - '*.kcd.sikademo.com'
+        - 'nyancat.kcd.sikademo.com'
       secretName: nginx-tls
   rules:
     - host: 'nyancat.kcd.sikademo.com'


### PR DESCRIPTION
My cluster issuer use HTTP challenge, so I'm not able to issue a wildcard cert.